### PR TITLE
[TASK] Remove call to non existing install:generatepackagestates command

### DIFF
--- a/src/Composer/InstallerScripts.php
+++ b/src/Composer/InstallerScripts.php
@@ -32,10 +32,6 @@ class InstallerScripts implements InstallerScriptsRegistration
     public static function register(Event $event, ScriptDispatcher $scriptDispatcher)
     {
         $scriptDispatcher->addInstallerScript(
-            new ConsoleCommand('install:generatepackagestates', [], '', null, false),
-            20
-        );
-        $scriptDispatcher->addInstallerScript(
             new ConsoleCommand('install:fixfolderstructure', [], '', null, false),
             20
         );


### PR DESCRIPTION
The command is no longer available in TYPO3 11.
