### PR TITLE
[BUGFIX] Fix auto commands in composer environment

### DIFF
--- a/src/Composer/InstallerScript/ConsoleCommand.php
+++ b/src/Composer/InstallerScript/ConsoleCommand.php
@@ -82,7 +82,7 @@ class ConsoleCommand implements InstallerScript
             $io->writeError(sprintf('<info>%s</info>', $this->message));
         }
 
-        $commandDispatcher = CommandDispatcher::createFromComposerRun($event);
+        $commandDispatcher = CommandDispatcher::createFromComposerRun($event, [], ['COMPOSER_VERSION' => $event->getComposer()::getVersion()]);
         try {
             $output = $commandDispatcher->executeCommand($this->command, $this->arguments);
             $io->writeError($output, true, $io::VERBOSE);


### PR DESCRIPTION
Handover composer version to CommandDispatcher to can use different
symfony/console api call based on composer version.

See: https://github.com/TYPO3-Console/TYPO3-Console/issues/1042