### PR TITLE
[TASK] Respect TYPO3 v12 file config/system/settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The following TYPO3 Console commands are executed:
 * `install:generatepackagestates` (only TYPO3 Console lower than 7.0)
 * `install:fixfolderstructure`
 
-And in the case TYPO3 appears to be setup properly (`LocalConfiguration.php`
-file is not missing) and running composer in dev mode (without `--no-dev`) these
-commands are also executed:
+And in the case TYPO3 appears to be setup properly (`typo3conf/LocalConfiguration.php` or
+`config/system/settings.php` file is not missing) and running composer in dev mode
+(without `--no-dev`) these commands are also executed:
 
 * `extension:setup` (or `extension:setupactive` in TYPO3 Console versions lower than 7.0)
 

--- a/src/Composer/InstallerScripts.php
+++ b/src/Composer/InstallerScripts.php
@@ -35,7 +35,9 @@ class InstallerScripts implements InstallerScriptsRegistration
             new ConsoleCommand('install:fixfolderstructure', [], '', null, false),
             20
         );
-        $typo3IsSetUp = getenv('TYPO3_IS_SET_UP') || file_exists(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php');
+        $typo3IsSetUp = getenv('TYPO3_IS_SET_UP')
+            || file_exists(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php')
+            || file_exists(getenv('TYPO3_PATH_APP') . '/config/system/settings.php');
         if ($typo3IsSetUp && $event->isDevMode()) {
             $scriptDispatcher->addInstallerScript(
                 new ConsoleCommand('extension:setup'),


### PR DESCRIPTION
In TYPO3 v12 the well known `typo3conf/LocalConfiguration.php` is located at `config/system/settings.php`. This change brings back the automatic invocation of the `extension:setup` command.